### PR TITLE
Add Dockerfile for ease of running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM oven/bun:latest
+
+RUN apt update && apt install git -y
+
+RUN git clone https://github.com/kurisubrooks/tfnsw-pids --branch feat/rewrite .
+
+RUN bun install
+
+EXPOSE 5173 
+ENTRYPOINT [ "bun", "run", "dev", "--host" ]


### PR DESCRIPTION
Add a Dockerfile for ease of running. 

For the children playing along at home, basically this is how it works: 

- Install Docker (Orbstack, et al)
- Clone the repository
- Execute `docker build -t tfnswpids:latest -f Dockerfile .`
- Let it build
- Execute it `docker run -d -p 5173:5173 --name tfnswpids tfnswpids:latest`
- Hit up http://localhost:5173/2000339 (as an example) in the browser and it should just work.

Has been tested using OrbStack on macOS. Should be agnostic to Windows/Linux as well. 

The dockerfile will pull the current code, regardless of what is in your local directory, so you should be able to just copy the Dockerfile and build it. 